### PR TITLE
Set up integration test environment using Testcontainers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,10 @@ dependencies {
 
 	// spock mock
 	testImplementation('net.bytebuddy:byte-buddy:1.12.10')
+
+	// testcontainers
+	testImplementation 'org.testcontainers:spock:1.19.8'
+	testImplementation 'org.testcontainers:mariadb:1.19.8'
 }
 
 tasks.named('test') {

--- a/src/test/groovy/com/laphayen/pharmacyrecommendation/AbstractIntegrationContainerBaseTest.groovy
+++ b/src/test/groovy/com/laphayen/pharmacyrecommendation/AbstractIntegrationContainerBaseTest.groovy
@@ -1,0 +1,23 @@
+package com.laphayen.pharmacyrecommendation
+
+import org.springframework.boot.test.context.SpringBootTest
+import org.testcontainers.containers.GenericContainer
+import spock.lang.Specification
+
+@SpringBootTest
+abstract class AbstractIntegrationContainerBaseTest extends Specification {
+
+    static final GenericContainer MY_REDIS_CONTAINER
+
+    static {
+        MY_REDIS_CONTAINER = new GenericContainer<>("redis:6")
+                .withExposedPorts(6379)
+
+        MY_REDIS_CONTAINER.start()
+
+        System.setProperty("spring.redis.host", MY_REDIS_CONTAINER.getHost())
+        System.setProperty("spring.redis.port", MY_REDIS_CONTAINER.getMappedPort(6379).toString())
+        
+    }
+
+}

--- a/src/test/groovy/com/laphayen/pharmacyrecommendation/api/pharmacy/repository/PharmacyRepositoryTest.groovy
+++ b/src/test/groovy/com/laphayen/pharmacyrecommendation/api/pharmacy/repository/PharmacyRepositoryTest.groovy
@@ -1,16 +1,37 @@
 package com.laphayen.pharmacyrecommendation.api.pharmacy.repository
 
+import com.laphayen.pharmacyrecommendation.AbstractIntegrationContainerBaseTest
+import com.laphayen.pharmacyrecommendation.api.pharmacy.entity.Pharmacy
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import spock.lang.Specification
 
-@SpringBootTest
-class PharmacyRepositoryTest extends Specification {
+class PharmacyRepositoryTest extends AbstractIntegrationContainerBaseTest {
 
     @Autowired
     private PharmacyRepository pharmacyRepository
 
-    def "test"() {
+
+    def "PharmacyRepository save"() {
+        given:
+        String address = "서울 특별시 성북구 종암동"
+        String name = "은혜 약국"
+        double latitude = 36.11
+        double longitude = 128.11
+
+        def pharmacy = Pharmacy.builder()
+                .pharmacyAddress(address)
+                .pharmacyName(name)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build()
+
+        when:
+        def result = pharmacyRepository.save(pharmacy)
+
+        then:
+        result.getPharmacyAddress() == address
+        result.getPharmacyName() == name
+        result.getLatitude() == latitude
+        result.getLongitude() == longitude
 
     }
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mariadb:10:///
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+
+kakao:
+  rest:
+    api:
+      key: ${KAKAO_REST_API_KEY}


### PR DESCRIPTION
Set up the test environment using Testcontainers.

Automatically start a MariaDB container in the test environment, create the database schema via Hibernate, and log SQL queries for easier development and debugging.
Set the Kakao REST API key as an environment variable to configure communication with the external API.
Set up a Redis container for integration testing using Testcontainers.

This closes #9 