### PR TITLE
JPA Dirty Checking

### DIFF
--- a/src/main/java/com/laphayen/pharmacyrecommendation/api/pharmacy/entity/Pharmacy.java
+++ b/src/main/java/com/laphayen/pharmacyrecommendation/api/pharmacy/entity/Pharmacy.java
@@ -25,4 +25,8 @@ public class Pharmacy {
     private double latitude;
     private double longitude;
 
+    public void changePharmacyAddress(String address) {
+        this.pharmacyAddress = address;
+    }
+
 }

--- a/src/main/java/com/laphayen/pharmacyrecommendation/api/pharmacy/service/PharmacyRepositoryService.java
+++ b/src/main/java/com/laphayen/pharmacyrecommendation/api/pharmacy/service/PharmacyRepositoryService.java
@@ -1,0 +1,41 @@
+package com.laphayen.pharmacyrecommendation.api.pharmacy.service;
+
+import com.laphayen.pharmacyrecommendation.api.pharmacy.entity.Pharmacy;
+import com.laphayen.pharmacyrecommendation.api.pharmacy.repository.PharmacyRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PharmacyRepositoryService {
+    private final PharmacyRepository pharmacyRepository;
+
+    @Transactional
+    public void updateAddress(Long id, String address) {
+        Pharmacy entity = pharmacyRepository.findById(id).orElse(null);
+
+        if(Objects.isNull(entity)) {
+            log.error("[PharmacyRepositoryService updateAddress] not found id: {}", id);
+            return;
+        }
+
+        entity.changePharmacyAddress(address);
+    }
+
+    // for test
+    public void updateAddressWithoutTransaction(Long id, String address) {
+        Pharmacy entity = pharmacyRepository.findById(id).orElse(null);
+
+        if(Objects.isNull(entity)) {
+            log.error("[PharmacyRepositoryService updateAddress] not found id: {}", id);
+            return;
+        }
+
+        entity.changePharmacyAddress(address);
+    }
+}

--- a/src/test/groovy/com/laphayen/pharmacyrecommendation/api/pharmacy/service/PharmacyRepositoryServiceTest.groovy
+++ b/src/test/groovy/com/laphayen/pharmacyrecommendation/api/pharmacy/service/PharmacyRepositoryServiceTest.groovy
@@ -1,0 +1,61 @@
+package com.laphayen.pharmacyrecommendation.api.pharmacy.service
+
+import com.laphayen.pharmacyrecommendation.AbstractIntegrationContainerBaseTest
+import com.laphayen.pharmacyrecommendation.api.pharmacy.entity.Pharmacy
+import com.laphayen.pharmacyrecommendation.api.pharmacy.repository.PharmacyRepository
+import org.springframework.beans.factory.annotation.Autowired
+
+class PharmacyRepositoryServiceTest extends AbstractIntegrationContainerBaseTest {
+
+    @Autowired
+    private PharmacyRepositoryService pharmacyRepositoryService
+
+    @Autowired
+    private PharmacyRepository pharmacyRepository
+
+    def setup() {
+        pharmacyRepository.deleteAll()
+    }
+
+    def "PharmacyRepository update - dirty checking success"() {
+        given:
+        String inputAddress = "서울 특별시 성북구 종암동"
+        String modifiedAddress = "서울 광진구 구의동"
+        String name = "은혜 약국"
+
+        def pharmacy = Pharmacy.builder()
+                .pharmacyAddress(inputAddress)
+                .pharmacyName(name)
+                .build()
+
+        when:
+        def entity = pharmacyRepository.save(pharmacy)
+        pharmacyRepositoryService.updateAddress(entity.getId(), modifiedAddress)
+
+        def result = pharmacyRepository.findAll()
+
+        then:
+        result.get(0).getPharmacyAddress() == modifiedAddress
+    }
+
+    def "PharmacyRepository update - dirty checking fail"() {
+        given:
+        String inputAddress = "서울 특별시 성북구 종암동"
+        String modifiedAddress = "서울 광진구 구의동"
+        String name = "은혜 약국"
+
+        def pharmacy = Pharmacy.builder()
+                .pharmacyAddress(inputAddress)
+                .pharmacyName(name)
+                .build()
+
+        when:
+        def entity = pharmacyRepository.save(pharmacy)
+        pharmacyRepositoryService.updateAddressWithoutTransaction(entity.getId(), modifiedAddress)
+
+        def result = pharmacyRepository.findAll()
+
+        then:
+        result.get(0).getPharmacyAddress() == inputAddress
+    }
+}


### PR DESCRIPTION
Apply JPA Dirty Checking to Pharmacy entity and use PharmacyRepository. 
Perform update operations within a transaction.
Test success and failure of dirty checking in updating pharmacy addresses.

This closes #17 