### PR TITLE
Transaction test for Pharmacy entity

### DIFF
--- a/src/main/java/com/laphayen/pharmacyrecommendation/api/pharmacy/service/PharmacyRepositoryService.java
+++ b/src/main/java/com/laphayen/pharmacyrecommendation/api/pharmacy/service/PharmacyRepositoryService.java
@@ -2,11 +2,13 @@ package com.laphayen.pharmacyrecommendation.api.pharmacy.service;
 
 import com.laphayen.pharmacyrecommendation.api.pharmacy.entity.Pharmacy;
 import com.laphayen.pharmacyrecommendation.api.pharmacy.repository.PharmacyRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import java.util.List;
 import java.util.Objects;
 
 @Slf4j
@@ -14,6 +16,31 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public class PharmacyRepositoryService {
     private final PharmacyRepository pharmacyRepository;
+
+    // self invocation test
+    @Transactional
+    public void bar(List<Pharmacy> pharmacyList) {
+        log.info("bar CurrentTransactionName: "+ TransactionSynchronizationManager.getCurrentTransactionName());
+        foo(pharmacyList);
+    }
+
+    // self invocation test
+    @Transactional
+    public void foo(List<Pharmacy> pharmacyList) {
+        log.info("foo CurrentTransactionName: "+ TransactionSynchronizationManager.getCurrentTransactionName());
+        pharmacyList.forEach(pharmacy -> {
+            pharmacyRepository.save(pharmacy);
+            throw new RuntimeException("error"); // 예외 발생
+        });
+    }
+
+
+    // read only test
+    @Transactional(readOnly = true)
+    public void startReadOnlyMethod(Long id) {
+        pharmacyRepository.findById(id).ifPresent(pharmacy ->
+                pharmacy.changePharmacyAddress("서울 특별시 광진구"));
+    }
 
     @Transactional
     public void updateAddress(Long id, String address) {
@@ -38,4 +65,10 @@ public class PharmacyRepositoryService {
 
         entity.changePharmacyAddress(address);
     }
+
+    @Transactional(readOnly = true)
+    public List<Pharmacy> findAll() {
+        return pharmacyRepository.findAll();
+    }
+
 }

--- a/src/test/groovy/com/laphayen/pharmacyrecommendation/api/pharmacy/service/PharmacyRepositoryServiceTest.groovy
+++ b/src/test/groovy/com/laphayen/pharmacyrecommendation/api/pharmacy/service/PharmacyRepositoryServiceTest.groovy
@@ -58,4 +58,54 @@ class PharmacyRepositoryServiceTest extends AbstractIntegrationContainerBaseTest
         then:
         result.get(0).getPharmacyAddress() == inputAddress
     }
+
+    def "self invocation"() {
+
+        given:
+        String address = "서울 특별시 성북구 종암동"
+        String name = "은혜 약국"
+        double latitude = 36.11
+        double longitude = 128.11
+
+        def pharmacy = Pharmacy.builder()
+                .pharmacyAddress(address)
+                .pharmacyName(name)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build()
+
+        when:
+        pharmacyRepositoryService.bar(Arrays.asList(pharmacy))
+
+        then:
+        def e = thrown(RuntimeException.class)
+        def result = pharmacyRepositoryService.findAll()
+        result.size() == 0 // 트랜잭션이 적용되지 않는다( 롤백 적용 X )
+    }
+
+    def "transactional readOnly test - 읽기 전용일 경우 dirty checking 반영 되지 않는다. "() {
+
+        given:
+        String inputAddress = "서울 특별시 성북구"
+        String modifiedAddress = "서울 특별시 광진구"
+        String name = "은혜 약국"
+        double latitude = 36.11
+        double longitude = 128.11
+
+        def input = Pharmacy.builder()
+                .pharmacyAddress(inputAddress)
+                .pharmacyName(name)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build()
+
+        when:
+        def pharmacy = pharmacyRepository.save(input)
+        pharmacyRepositoryService.startReadOnlyMethod(pharmacy.id)
+
+        then:
+        def result = pharmacyRepositoryService.findAll()
+        result.get(0).getPharmacyAddress() == inputAddress
+    }
+
 }


### PR DESCRIPTION
Test transaction propagation and self-invocation, attempt data modification in a read-only transaction, and optimize by retrieving all pharmacy entities in read-only mode.
Test the impact of self-invocation on transaction rollback and verify that dirty checking is not reflected in read-only transactions.

This closes #21 